### PR TITLE
Updated renderer.rs

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -94,10 +94,9 @@ impl Renderer {
             khr_swapchain: true,
             ..DeviceExtensions::empty()
         };
-
-        // Don't request geometry shader support, as it is not supported on macOS
+        
         let features = Features {
-            // geometry_shader: true, // Removed as it is not supported by Metal/MoltenVK
+            geometry_shader: true,
             ..Features::empty()
         };
 
@@ -136,7 +135,7 @@ impl Renderer {
             physical_device.clone(),
             DeviceCreateInfo {
                 enabled_extensions: device_extensions,
-                enabled_features: features, // No geometry_shader feature request
+                enabled_features: features,
                 queue_create_infos: vec![QueueCreateInfo {
                     queue_family_index,
                     ..Default::default()


### PR DESCRIPTION
FYI: Probably not a good idea to merge this, this fix will probably break something on Windows lol

This allows wasabi to open on my MacBook (via `cargo run`), but when I open a midi, it runs into another error. Everything other than this works fine.
<img width="428" alt="image" src="https://github.com/user-attachments/assets/5d5a8ac4-f4cf-47d4-98bb-f54dc8dca62f">

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/adea9cde-f6b3-4199-805f-cd401b6396af">
