### PR TITLE
Fix BSD support hopefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "kdmapi"
 version = "0.1.0"
-source = "git+https://github.com/BlackMIDIDevs/kdmapi-rs?branch=bsd-support#57c36f57ed659ab705e265dbb27c5167f6c34766"
+source = "git+https://github.com/BlackMIDIDevs/kdmapi-rs?rev=994220f#994220fbbbcc1ec9a705fda2714937a0d15dfa67"
 dependencies = [
  "lazy_static",
  "libloading 0.7.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "kdmapi"
 version = "0.1.0"
-source = "git+https://github.com/BlackMIDIDevs/kdmapi-rs?rev=aa39558#aa395580d547583ff5fb968b6e6264efd9584f34"
+source = "git+https://github.com/BlackMIDIDevs/kdmapi-rs?branch=bsd-support#57c36f57ed659ab705e265dbb27c5167f6c34766"
 dependencies = [
  "lazy_static",
  "libloading 0.7.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "wasabi"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "atomic_float",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,10 @@ palette = "0.7.6"
 colors-transform = "0.2"
 numfmt = "1.2.0"
 
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows", target_os = "macos"))'.dependencies]
+kdmapi-rs = { package = "kdmapi", git = "https://github.com/BlackMIDIDevs/kdmapi-rs", branch = "bsd-support" }
+
 [target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))'.dependencies]
-kdmapi-rs = { package = "kdmapi", git = "https://github.com/BlackMIDIDevs/kdmapi-rs", rev = "aa39558" }
 midir = "0.10.2"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasabi"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ colors-transform = "0.2"
 numfmt = "1.2.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows", target_os = "macos"))'.dependencies]
-kdmapi-rs = { package = "kdmapi", git = "https://github.com/BlackMIDIDevs/kdmapi-rs", branch = "bsd-support" }
+kdmapi-rs = { package = "kdmapi", git = "https://github.com/BlackMIDIDevs/kdmapi-rs", rev = "994220f" }
 
 [target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))'.dependencies]
 midir = "0.10.2"

--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,12 @@ fn main() {
     #[cfg(not(windows))]
     println!("cargo:rerun-if-changed=assets/logo.svg");
 
-    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "windows",
+        target_os = "macos"
+    ))]
     println!("cargo:rustc-cfg=supported_os");
     println!("cargo::rustc-check-cfg=cfg(supported_os)");
 }

--- a/src/audio_playback/mod.rs
+++ b/src/audio_playback/mod.rs
@@ -13,16 +13,16 @@ mod kdmapi;
 #[cfg(supported_os)]
 pub use kdmapi::*;
 
-#[cfg(supported_os)]
+#[cfg(all(supported_os, not(target_os = "freebsd")))]
 mod midiout;
-#[cfg(supported_os)]
+#[cfg(all(supported_os, not(target_os = "freebsd")))]
 pub use midiout::*;
 
 enum MidiAudioPlayer {
     XSynth(XSynthPlayer),
     #[cfg(supported_os)]
     Kdmapi(KdmapiPlayer),
-    #[cfg(supported_os)]
+    #[cfg(all(supported_os, not(target_os = "freebsd")))]
     MidiDevice(MidiDevicePlayer),
     None,
 }
@@ -47,7 +47,7 @@ impl WasabiAudioPlayer {
             MidiAudioPlayer::XSynth(player) => player.push_events(data),
             #[cfg(supported_os)]
             MidiAudioPlayer::Kdmapi(player) => player.push_events(data),
-            #[cfg(supported_os)]
+            #[cfg(all(supported_os, not(target_os = "freebsd")))]
             MidiAudioPlayer::MidiDevice(player) => player.push_events(data),
             _ => {}
         }
@@ -83,7 +83,7 @@ impl WasabiAudioPlayer {
             MidiAudioPlayer::XSynth(player) => player.reset(),
             #[cfg(supported_os)]
             MidiAudioPlayer::Kdmapi(player) => player.reset(),
-            #[cfg(supported_os)]
+            #[cfg(all(supported_os, not(target_os = "freebsd")))]
             MidiAudioPlayer::MidiDevice(player) => player.reset(),
             _ => {}
         }
@@ -111,7 +111,7 @@ impl WasabiAudioPlayer {
                     MidiAudioPlayer::None
                 }
             },
-            #[cfg(supported_os)]
+            #[cfg(all(supported_os, not(target_os = "freebsd")))]
             Synth::MidiDevice => match MidiDevicePlayer::new(settings.midi_device.clone()) {
                 Ok(midiout) => MidiAudioPlayer::MidiDevice(midiout),
                 Err(e) => {

--- a/src/gui/window/settings.rs
+++ b/src/gui/window/settings.rs
@@ -190,12 +190,12 @@ impl SettingsWindow {
         Ok(())
     }
 
-    #[cfg(not(supported_os))]
+    #[cfg(any(not(supported_os), target_os = "freebsd"))]
     pub fn load_midi_devices(&mut self, _settings: &mut WasabiSettings) -> Result<(), WasabiError> {
         Ok(())
     }
 
-    #[cfg(supported_os)]
+    #[cfg(all(supported_os, not(target_os = "freebsd")))]
     pub fn load_midi_devices(&mut self, settings: &mut WasabiSettings) -> Result<(), WasabiError> {
         self.midi_devices.clear();
         let con = midir::MidiOutput::new("wasabi")

--- a/src/gui/window/settings.rs
+++ b/src/gui/window/settings.rs
@@ -24,7 +24,7 @@ struct FilePalette {
     pub selected: bool,
 }
 
-#[cfg(supported_os)]
+#[cfg(all(supported_os, not(target_os = "freebsd")))]
 #[derive(Clone)]
 struct MidiDevice {
     pub name: String,
@@ -33,7 +33,7 @@ struct MidiDevice {
 
 pub struct SettingsWindow {
     palettes: Vec<FilePalette>,
-    #[cfg(supported_os)]
+    #[cfg(all(supported_os, not(target_os = "freebsd")))]
     midi_devices: Vec<MidiDevice>,
     sf_list: EguiSFList,
 }

--- a/src/gui/window/settings.rs
+++ b/src/gui/window/settings.rs
@@ -47,7 +47,7 @@ impl SettingsWindow {
 
         Self {
             palettes: Vec::new(),
-            #[cfg(supported_os)]
+            #[cfg(all(supported_os, not(target_os = "freebsd")))]
             midi_devices: Vec::new(),
             sf_list,
         }

--- a/src/gui/window/settings/synth.rs
+++ b/src/gui/window/settings/synth.rs
@@ -7,7 +7,7 @@ use super::SettingsWindow;
 
 #[cfg(supported_os)]
 mod kdmapi;
-#[cfg(supported_os)]
+#[cfg(all(supported_os, not(target_os = "freebsd")))]
 mod mididevice;
 mod xsynth;
 
@@ -42,7 +42,7 @@ impl SettingsWindow {
                                 Synth::Kdmapi,
                                 Synth::Kdmapi.as_str(),
                             );
-                            #[cfg(supported_os)]
+                            #[cfg(all(supported_os, not(target_os = "freebsd")))]
                             ui.selectable_value(
                                 &mut settings.synth.synth,
                                 Synth::MidiDevice,
@@ -86,7 +86,7 @@ impl SettingsWindow {
             Synth::XSynth => self.show_xsynth_settings(ui, settings, state, width),
             #[cfg(supported_os)]
             Synth::Kdmapi => self.show_kdmapi_settings(ui, settings, state, width),
-            #[cfg(supported_os)]
+            #[cfg(all(supported_os, not(target_os = "freebsd")))]
             Synth::MidiDevice => self.show_mididevice_settings(ui, settings, state, width),
             Synth::None => {
                 ui.label("No Settings");

--- a/src/settings/enums.rs
+++ b/src/settings/enums.rs
@@ -47,7 +47,7 @@ pub enum Synth {
     XSynth = 0,
     #[cfg(supported_os)]
     Kdmapi = 1,
-    #[cfg(supported_os)]
+    #[cfg(all(supported_os, not(target_os = "freebsd")))]
     MidiDevice = 2,
     None = 3,
 }
@@ -59,7 +59,7 @@ impl Synth {
             Synth::XSynth => "Built-In (XSynth)",
             #[cfg(supported_os)]
             Synth::Kdmapi => "KDMAPI",
-            #[cfg(supported_os)]
+            #[cfg(all(supported_os, not(target_os = "freebsd")))]
             Synth::MidiDevice => "MIDI Device",
             Synth::None => "None",
         }

--- a/src/settings/enums.rs
+++ b/src/settings/enums.rs
@@ -74,7 +74,7 @@ impl FromStr for Synth {
             "xsynth" => Ok(Synth::XSynth),
             #[cfg(supported_os)]
             "kdmapi" => Ok(Synth::Kdmapi),
-            #[cfg(supported_os)]
+            #[cfg(all(supported_os, not(target_os = "freebsd")))]
             "mididevice" => Ok(Synth::MidiDevice),
             "none" => Ok(Synth::None),
             s => Err(format!(


### PR DESCRIPTION
This makes it so Wasabi properly compiles on FreeBSD. I would add support for other BSD's but I only actually tested FreeBSD.

This depends on: https://github.com/BlackMIDIDevs/kdmapi-rs/pull/2

Fixes #105 